### PR TITLE
test: expand integration coverage and fix strict null check

### DIFF
--- a/data/sepolia-known-locks.json
+++ b/data/sepolia-known-locks.json
@@ -84,38 +84,87 @@
     "source": "addLocks:ad5fcf187b30"
   },
   {
-    "address": "0x5E7760Acf5d659278747b95DA2Ab2B5Ea7171615",
+    "address": "0x0000000000000000000000000000000000000034",
     "amount": "1.0",
-    "cliffDate": 1721724123,
-    "lockEndDate": 1724402523,
-    "source": "addLocks:0xd4bef9b5"
+    "cliffDate": 1748736000,
+    "lockEndDate": 1751328000,
+    "source": "addLocks:5ff3bec92f79"
   },
   {
-    "address": "0x8108457554bc5822dC55B8ADAA421Ffeb970E09D",
+    "address": "0x0000000000000000000000000000000000000035",
     "amount": "1.0",
-    "cliffDate": 1721724123,
-    "lockEndDate": 1724402523,
-    "source": "addLocks:0xd4bef9b5"
+    "cliffDate": 1748736000,
+    "lockEndDate": 1751328000,
+    "source": "addLocks:5ff3bec92f79"
   },
   {
-    "address": "0x4b595014f7b45789c3f4E79324aE6D8090A6C8B5",
+    "address": "0x0000000000000000000000000000000000000036",
     "amount": "1.0",
-    "cliffDate": 1721724123,
-    "lockEndDate": 1724402523,
-    "source": "addLocks:0xd4bef9b5"
+    "cliffDate": 1748736000,
+    "lockEndDate": 1764547200,
+    "source": "addLocks:5ff3bec92f79"
   },
   {
-    "address": "0xB5a15932Be6caEeF5d21AC704300bd45e10ff92d",
+    "address": "0x0000000000000000000000000000000000000037",
     "amount": "1.0",
-    "cliffDate": 1721724123,
-    "lockEndDate": 1724402523,
-    "source": "addLocks:0xd4bef9b5"
+    "cliffDate": 1748736000,
+    "lockEndDate": 1764547200,
+    "source": "addLocks:5ff3bec92f79"
   },
   {
-    "address": "0x8533F3FFe30C9cf449CC112850e7EC815070509d",
+    "address": "0x0000000000000000000000000000000000000031",
     "amount": "1.0",
-    "cliffDate": 1721724123,
-    "lockEndDate": 1724402523,
-    "source": "addLocks:0xd4bef9b5"
+    "cliffDate": 1748736000,
+    "lockEndDate": 1751328000,
+    "source": "addLocks:99d36b62bacc"
+  },
+  {
+    "address": "0x0000000000000000000000000000000000000032",
+    "amount": "1.0",
+    "cliffDate": 1748736000,
+    "lockEndDate": 1751328000,
+    "source": "addLocks:99d36b62bacc"
+  },
+  {
+    "address": "0x0000000000000000000000000000000000000033",
+    "amount": "1.0",
+    "cliffDate": 1748736000,
+    "lockEndDate": 1751328000,
+    "source": "addLocks:99d36b62bacc"
+  },
+  {
+    "address": "0x0000000000000000000000000000000000000030",
+    "amount": "1.0",
+    "cliffDate": 1748736000,
+    "lockEndDate": 1751328000,
+    "source": "addLocks:4eeaffe1fc95"
+  },
+  {
+    "address": "0x073F18d260dC35d40Aa5375a3DDEE1616F59F5dd",
+    "amount": "1.0",
+    "cliffDate": 1756684800,
+    "lockEndDate": 1780272000,
+    "source": "addLocks:1300c98a5fd7"
+  },
+  {
+    "address": "0x822685E68d5d4C1C64973d831A13Ebd3ed3C9b55",
+    "amount": "1.0",
+    "cliffDate": 1756684800,
+    "lockEndDate": 1780272000,
+    "source": "verified:addLocks:1a7b87ededc1"
+  },
+  {
+    "address": "0x822685E68d5d4C1C64973d831A13Ebd3ed3C9b55",
+    "amount": "1.0",
+    "cliffDate": 1756684800,
+    "lockEndDate": 1780272000,
+    "source": "updateLocks:152b8bfa40de"
+  },
+  {
+    "address": "0xc10846231A3B77765cC771e95BD70222956ba50b",
+    "amount": "1.0",
+    "cliffDate": 1748736000,
+    "lockEndDate": 1811808000,
+    "source": "addLocks:843857748fde"
   }
 ]

--- a/test/README.md
+++ b/test/README.md
@@ -300,7 +300,7 @@ These tests require a Sepolia RPC endpoint. Set `OMA3_OPS_RPC_URL_SEPOLIA` in th
 
 Sepolia contract addresses (from README):
 - OMA: `0xd7ee0eADb283eFB6d6e628De5E31A284183f4EDf`
-- OMA Lock: `0x2f38D6cCB480d5C7e68d11b5a02f2c2451543F58`
+- OMA Lock: `0xfD1410e3A80A0f311804a09C656d98a82B7c5d9f`
 
 #### `lock-status.test.ts`
 
@@ -426,120 +426,229 @@ Integration tests load known wallet data from `data/<network>-known-locks.json`.
 
 ## Manual Testing
 
-These procedures document how to exercise the Safe Transaction Builder interface end-to-end on Sepolia. They complement the automated test suite by verifying the full human workflow: generate artifacts, import into Safe UI, and confirm on-chain results.
+These procedures document how to exercise the Safe Transaction Builder interface end-to-end on Sepolia. They complement the automated test suite by verifying the full human workflow: generate artifacts, fund the Admin Safe, import into Safe UI, execute, and confirm on-chain results.
+
+### Contract addresses (Sepolia)
+
+| Contract | Address |
+|----------|---------|
+| OMA Token | `0xd7ee0eADb283eFB6d6e628De5E31A284183f4EDf` |
+| OMALock | `0xfD1410e3A80A0f311804a09C656d98a82B7c5d9f` |
+| Admin Safe | `0x1DB7fa65bB67176196E7bB3286019CC8714c8184` |
+| Treasury Safe | `0x116328754149da56674D1034871eeE08B7864D34` |
 
 ### Pre-requisites
 
-- A Safe multisig wallet on Sepolia (`app.safe.global`)
-- Sepolia ETH in the Safe for gas
-- Sepolia OMA tokens (contract `0xd7ee0eADb283eFB6d6e628De5E31A284183f4EDf`)
-- A Sepolia RPC endpoint (set `OMA3_OPS_RPC_URL_SEPOLIA`)
-- Node.js and project dependencies installed (`npm install`)
-- A test CSV with wallet addresses and amounts (see `test/fixtures/valid-3-wallets.csv` for format)
+- Signer access to the Admin Safe and Treasury Safe on Sepolia at `app.safe.global`
+- Sepolia ETH in the signer wallet (for gas when confirming Safe transactions)
+- Sepolia OMA tokens in the Treasury Safe (or another funded wallet)
+- A Sepolia RPC endpoint — set via `.env.local` or environment variable:
+  ```bash
+  export OMA3_OPS_RPC_URL_SEPOLIA=https://your-sepolia-rpc-url
+  ```
+- Node.js 20+ and project dependencies installed:
+  ```bash
+  npm install && npm run build
+  ```
 
-### Procedure 1: Generate and import an addLocks transaction
+### Procedure 1: Fund the Admin Safe with OMA tokens
 
-1. Prepare a CSV (e.g. `test-add.csv`) with 2-3 test wallets that have no existing locks:
+The Admin Safe must hold enough OMA to cover the `addLocks` batch. If your OMA tokens are in a Treasury Safe, transfer them first.
+
+Safe has built-in support for ERC-20 token transfers — no Transaction Builder required. The Transaction Builder is only needed for custom contract calls that Safe doesn't have a UI for (like `addLocks()`, `updateLocks()`, `slash()`, etc.).
+
+1. **Send OMA from the Treasury Safe:**
+   - Go to `app.safe.global` > select the **Treasury Safe** (`0x1163...D34`)
+   - If OMA doesn't appear in the asset list, add it manually by pasting the OMA token contract address: `0xd7ee0eADb283eFB6d6e628De5E31A284183f4EDf`
+   - Click the **New Transaction** button (green button in the left column) > **Send tokens**
+   - Select OMA as the token
+   - Set the recipient to the Admin Safe: `0x1DB7fa65bB67176196E7bB3286019CC8714c8184`
+   - Enter the amount (e.g. `3` for 3 OMA — the UI handles the wei conversion)
+   - Review and submit
+   - Sign with your signer wallet (MetaMask or similar)
+   - Collect additional signer approvals if the Safe threshold requires it
+
+2. **Confirm the transfer:**
+   - Check the Admin Safe balance on [Sepolia Etherscan](https://sepolia.etherscan.io/address/0x1DB7fa65bB67176196E7bB3286019CC8714c8184#tokentxns)
+   - Verify the OMA balance matches the transferred amount
+
+### Procedure 2: Generate and import an addLocks transaction
+
+1. **Prepare a test CSV** (e.g. `data/runs/sepolia/<date>-addLocks/input.csv`):
    ```
    address,amount,cliffOffsetMonths,lockEndOffsetMonths
-   0xWALLET1,1000,6,12
-   0xWALLET2,2000,6,24
+   0x073F18d260dC35d40Aa5375a3DDEE1616F59F5dd,1,0,1
+   0x822685E68d5d4C1C64973d831A13Ebd3ed3C9b55,1,0,1
+   0xc10846231A3B77765cC771e95BD70222956ba50b,1,0,24
    ```
-2. Generate the transaction:
+   Use `cliffOffsetMonths=0` and short `lockEndOffsetMonths` for test wallets so vesting completes quickly and you can test `claim()`.
+
+2. **Generate the Safe transaction:**
    ```bash
-   npm run lock-add-locks -- --csv test-add.csv --anchor-date-utc 2025-06-01T00:00:00Z --network sepolia --out-dir output/
+   npm run lock-add-locks -- \
+     --csv data/runs/sepolia/2026-03-18-001-addLocks/input.csv \
+     --anchor-date-utc 2025-06-01T00:00:00Z \
+     --network sepolia \
+     --rpc-url $OMA3_OPS_RPC_URL_SEPOLIA \
+     --out-dir data/runs/sepolia/2026-03-18-001-addLocks/
    ```
-3. Verify output files:
-   - `output/safe-tx.json` — the Safe batch file
-   - `output/safe-tx.summary.txt` — human-readable summary
-4. Open the summary and verify:
-   - Wallet addresses match the CSV
-   - Amounts match (both human-readable OMA and wei)
-   - Cliff and lockEnd dates are correct for the given anchor + offsets
-   - `Validation: PASS`
-5. Verify SHA256 of the JSON file matches the summary:
+
+3. **Verify output files:**
+   - `safe-tx.json` — the Safe batch file
+   - `safe-tx.summary.txt` — human-readable summary
+   - Open the summary and check: wallet addresses match CSV, amounts match, cliff/lockEnd dates are correct, `Validation: PASS`
+
+4. **Verify the SHA256:**
    ```bash
-   sha256sum output/safe-tx.json
+   # Linux/macOS
+   sha256sum safe-tx.json
+   # Windows PowerShell
+   Get-FileHash safe-tx.json -Algorithm SHA256
    ```
    Compare with the `JSON SHA256:` line in the summary.
-6. Import `safe-tx.json` into Safe Transaction Builder:
-   - Go to `app.safe.global` > your Sepolia Safe > New Transaction > Transaction Builder
-   - Upload `safe-tx.json`
-   - Verify the correct number of transactions appear
-   - Verify each transaction shows `addLocks` as the method
-   - Verify decoded parameters match the summary (wallets, amounts, cliff/lockEnd timestamps)
-7. Verify calldata hash:
-   - Copy raw calldata hex from Safe UI for each transaction
-   - Run `npm run hash -- <hex>` and confirm the result matches `calldataHash` in the summary
-8. Verify batch fingerprint:
-   - Confirm the `Batch Fingerprint` in the summary matches the batch metadata shown by Safe UI
 
-### Procedure 2: Generate and import an updateLocks transaction
-
-1. Use wallets from Procedure 1 that already have locks.
-2. Generate:
-   ```bash
-   npm run lock-update-locks -- --csv test-update.csv --anchor-date-utc 2025-06-01T00:00:00Z --network sepolia --out-dir output/
+5. **Create a combined approve + addLocks batch (recommended).** The Admin Safe must first `approve` the OMALock contract to spend its OMA tokens. Instead of two separate transactions, combine them into one batch file. Prepend an `approve` transaction before the `addLocks` transactions in `safe-tx.json`:
+   ```json
+   {
+     "to": "0xd7ee0eADb283eFB6d6e628De5E31A284183f4EDf",
+     "value": "0",
+     "data": null,
+     "contractMethod": {
+       "name": "approve",
+       "payable": false,
+       "inputs": [
+         { "internalType": "address", "name": "spender", "type": "address" },
+         { "internalType": "uint256", "name": "amount", "type": "uint256" }
+       ]
+     },
+     "contractInputsValues": {
+       "spender": "0xfD1410e3A80A0f311804a09C656d98a82B7c5d9f",
+       "amount": "3000000000000000000"
+     }
+   }
    ```
-   (The CSV for `updateLocks` uses the same columns but amounts are ignored by the contract.)
-3. Import into Safe Transaction Builder and verify:
+   Set `amount` to the total OMA in the batch (in wei). Insert this as the first element of the `transactions` array in `safe-tx.json` and save as `safe-tx-with-approve.json`.
+
+6. **Import into Safe UI (Admin Safe):**
+   - Go to `app.safe.global` > select the **Admin Safe** (`0x1DB7...184`)
+   - Click **New Transaction** > **Transaction Builder**
+   - Upload `safe-tx-with-approve.json`
+   - Verify: first transaction is `approve`, remaining are `addLocks`
+   - Check decoded parameters: spender is the OMALock address, approve amount matches total, wallet addresses and amounts in `addLocks` match the summary
+   - Click **Create Batch** > **Send Batch** > sign and execute
+
+7. **Verify on-chain:**
+   ```bash
+   npm run lock-status -- \
+     --wallet 0x073F18d260dC35d40Aa5375a3DDEE1616F59F5dd \
+              0x822685E68d5d4C1C64973d831A13Ebd3ed3C9b55 \
+              0xc10846231A3B77765cC771e95BD70222956ba50b \
+     --network sepolia \
+     --rpc-url $OMA3_OPS_RPC_URL_SEPOLIA
+   ```
+   Confirm each wallet shows `hasLock: true` with matching amounts and dates.
+
+### Procedure 3: Generate and import an updateLocks transaction
+
+1. Use wallets from Procedure 2 that already have locks.
+2. **Generate:**
+   ```bash
+   npm run lock-update-locks -- \
+     --csv test-update.csv \
+     --anchor-date-utc 2025-06-01T00:00:00Z \
+     --network sepolia \
+     --rpc-url $OMA3_OPS_RPC_URL_SEPOLIA \
+     --out-dir output/
+   ```
+   The CSV uses the same columns; amounts are ignored by the contract for `updateLocks`.
+3. **Import into Safe Transaction Builder (Admin Safe)** and verify:
    - Method is `updateLocks`
-   - No amounts parameter in the decoded calldata
+   - No `amounts_` parameter in the decoded calldata
    - Wallet addresses match
    - New cliff and lockEnd dates match the updated offsets
-4. Execute and verify with `lock-status`:
+4. **Execute and verify:**
    ```bash
-   npm run lock-status -- --wallet 0xWALLET1 0xWALLET2 --network sepolia
+   npm run lock-status -- \
+     --wallet 0x073F18d260dC35d40Aa5375a3DDEE1616F59F5dd \
+              0x822685E68d5d4C1C64973d831A13Ebd3ed3C9b55 \
+     --network sepolia \
+     --rpc-url $OMA3_OPS_RPC_URL_SEPOLIA
    ```
-   Confirm the cliff and lockEnd dates reflect the update.
+   Confirm cliff and lockEnd dates reflect the update.
 
-### Procedure 3: Generate and import slash and slashStake transactions
+### Procedure 4: Generate and import slash and slashStake transactions
 
 1. For `slash`, prepare a CSV with wallets to slash:
    ```
    address
    0xWALLET_TO_SLASH
    ```
-2. Generate:
+2. **Generate:**
    ```bash
-   npm run lock-slash -- --csv test-slash.csv --network sepolia --to 0xRECIPIENT --out-dir output/
+   npm run lock-slash -- \
+     --csv test-slash.csv \
+     --network sepolia \
+     --rpc-url $OMA3_OPS_RPC_URL_SEPOLIA \
+     --to 0xRECIPIENT \
+     --out-dir output/
    ```
-3. For `slashStake`, prepare a CSV with wallets and amounts:
+3. For `slashStake`, prepare a CSV with wallets and staked amounts:
    ```
-   address,amount
+   address,stakedAmount
    0xWALLET_TO_SLASH,500
    ```
-4. Generate:
+4. **Generate:**
    ```bash
-   npm run lock-slash-stake -- --csv test-slash-stake.csv --network sepolia --to 0xRECIPIENT --out-dir output/
+   npm run lock-slash-stake -- \
+     --csv test-slash-stake.csv \
+     --network sepolia \
+     --rpc-url $OMA3_OPS_RPC_URL_SEPOLIA \
+     --to 0xRECIPIENT \
+     --out-dir output/
    ```
-5. Import each into Safe Transaction Builder and verify:
+5. **Import each into Safe Transaction Builder (Admin Safe)** and verify:
    - `slash` transactions show the correct `wallet_` and `to_` parameters
-   - `slashStake` transactions show the correct `wallet_`, `amount_`, and `to_` parameters
+   - `slashStake` transactions show the correct `wallet_`, `stakedAmount_`, and `to_` parameters
 6. Execute and verify with `lock-status` that the slashed/staked amounts changed accordingly.
 
-### Procedure 4: Verify summary SHA256 and batch fingerprint after Safe import
+### Procedure 5: Verify summary SHA256 and batch fingerprint after Safe import
 
-1. After importing any `safe-tx.json` into Safe UI, re-verify:
+1. After importing any `safe-tx.json` into Safe UI, re-verify the SHA256:
    ```bash
+   # Linux/macOS
    sha256sum output/safe-tx.json
+   # Windows PowerShell
+   Get-FileHash output/safe-tx.json -Algorithm SHA256
    ```
    Must match `JSON SHA256:` in the summary.
-2. For each transaction in the batch, copy the calldata hex from Safe UI and run:
+2. For each transaction in the batch, copy the raw calldata hex from Safe UI and run:
    ```bash
    npm run hash -- <calldata-hex>
    ```
    Each result must match the corresponding `calldataHash=` in the summary.
 3. The `Batch Fingerprint` is the keccak256 of the concatenated per-transaction calldata hashes. This value should remain stable as long as the JSON file is unmodified.
 
-### Procedure 5: Verify known-locks fixture update
+### Procedure 6: Verify known-locks fixture update
 
 1. After executing an `addLocks` transaction on Sepolia, run:
    ```bash
-   npm run lock-verify-json -- --network sepolia
+   npm run lock-verify-json -- \
+     --network sepolia \
+     --rpc-url $OMA3_OPS_RPC_URL_SEPOLIA
    ```
 2. Confirm all entries report `OK` (on-chain state matches fixture).
 3. If any report `MISMATCH`, the auto-fix (default on Sepolia) will update the fixture with on-chain values.
+
+### Troubleshooting
+
+| Symptom | Likely Cause | Fix |
+|---------|-------------|-----|
+| `GS013` revert on Safe execution | Admin Safe doesn't hold enough OMA tokens | Run Procedure 1 to fund the Admin Safe before executing addLocks |
+| `GS013` revert on single-transaction batch from Transaction Builder | Safe UI wraps single-transaction batches in MultiSend differently, causing execution to fail even when the underlying contract call is valid | Prepend a no-op `approve(OMALock, 0)` transaction to create a 2-transaction batch. Save as `safe-tx-batch.json` and upload that instead. Multi-transaction batches route through MultiSend correctly. |
+| `LockExist` revert | Trying to `addLocks` for wallets that already have locks | Use `updateLocks` instead, or use fresh wallet addresses |
+| `NoLock` revert | Trying to `updateLocks` for wallets with no existing lock | Use `addLocks` first |
+| Integration tests fail with `ENOENT` or `EINVAL` for tsx | Windows-specific issue with `execFileSync` | Ensure `shell: true` is set in test helpers (already fixed) |
+| Integration tests show `MISSING` entries | Fixture contains addresses not present on the new contract | Run `npm run lock-verify-json -- --network sepolia --auto-fix` to clean the fixture |
 
 ---
 

--- a/test/fixtures/valid-2-wallets-with-lock.csv
+++ b/test/fixtures/valid-2-wallets-with-lock.csv
@@ -1,0 +1,3 @@
+address,amount,cliffOffsetMonths,lockEndOffsetMonths
+0x073F18d260dC35d40Aa5375a3DDEE1616F59F5dd,1,6,12
+0x822685E68d5d4C1C64973d831A13Ebd3ed3C9b55,1,6,12

--- a/test/integration/end-to-end.test.ts
+++ b/test/integration/end-to-end.test.ts
@@ -14,6 +14,7 @@ import { createHash } from 'node:crypto';
 import { runLockCommand } from '../../src/run-lock-command.js';
 import { keccakHexBytes, batchFingerprint } from '../../src/hash-utils.js';
 import { assertNoUnknownOptions } from '../../src/cli-utils.js';
+import { loadFixtures } from '../../src/known-locks.js';
 
 const RPC_URL = process.env.OMA3_OPS_RPC_URL_SEPOLIA;
 
@@ -45,14 +46,20 @@ function makeArgs(overrides: Record<string, string | undefined> = {}): string[] 
   return args;
 }
 
+const knownLocksPath = resolve(process.cwd(), 'data', 'sepolia-known-locks.json');
+
 describeIf('end-to-end integration', () => {
+  let savedKnownLocks: string;
+
   beforeEach(() => {
     tmpDir = mkdtempSync(join(tmpdir(), 'e2e-test-'));
     outDir = join(tmpDir, 'output');
+    savedKnownLocks = readFileSync(knownLocksPath, 'utf8');
   });
 
   afterEach(() => {
     rmSync(tmpDir, { recursive: true, force: true });
+    writeFileSync(knownLocksPath, savedKnownLocks, 'utf8');
   });
 
   it('basic addLocks generation: 3-wallet CSV', async () => {
@@ -103,7 +110,7 @@ describeIf('end-to-end integration', () => {
 
   it('updateLocks generation', async () => {
     await runLockCommand('updateLocks', makeArgs({
-      '--csv': join(fixturesDir(), 'valid-2-wallets.csv'),
+      '--csv': join(fixturesDir(), 'valid-2-wallets-with-lock.csv'),
     }));
 
     const jsonPath = join(outDir, 'safe-tx.json');
@@ -264,5 +271,230 @@ describeIf('end-to-end integration', () => {
 
     const files = existsSync(outDir) ? readdirSync(outDir) : [];
     expect(files, 'Output directory must be empty after validation failure').toHaveLength(0);
+  });
+
+  it('--max-total-pct hard error: total exceeds default 10% of supply', async () => {
+    const csvPath = join(tmpDir, 'large-amount.csv');
+    writeFileSync(csvPath, [
+      'address,amount,cliffOffsetMonths,lockEndOffsetMonths',
+      '0x0000000000000000000000000000000000000001,20000000,6,12',
+      '0x0000000000000000000000000000000000000002,20000000,6,12',
+    ].join('\n') + '\n', 'utf8');
+
+    mkdirSync(outDir, { recursive: true });
+    await expect(
+      runLockCommand('addLocks', makeArgs({ '--csv': csvPath })),
+    ).rejects.toThrow(/exceeds --max-total-pct/);
+
+    const files = existsSync(outDir) ? readdirSync(outDir) : [];
+    expect(files, 'No output files on threshold error').toHaveLength(0);
+  });
+
+  it('--max-total-pct custom threshold passes', async () => {
+    const csvPath = join(tmpDir, 'large-amount.csv');
+    writeFileSync(csvPath, [
+      'address,amount,cliffOffsetMonths,lockEndOffsetMonths',
+      '0x0000000000000000000000000000000000000001,50000000,6,12',
+      '0x0000000000000000000000000000000000000002,50000000,6,12',
+    ].join('\n') + '\n', 'utf8');
+
+    await runLockCommand('addLocks', [
+      ...makeArgs({ '--csv': csvPath }),
+      '--max-total-pct', '50',
+    ]);
+
+    expect(existsSync(join(outDir, 'safe-tx.json'))).toBe(true);
+    expect(existsSync(join(outDir, 'safe-tx.summary.txt'))).toBe(true);
+
+    const summary = readFileSync(join(outDir, 'safe-tx.summary.txt'), 'utf8');
+    expect(summary).toContain('WARNING: --max-total-pct set to 50');
+  });
+
+  it('--warn-wallet-pct warnings appear in summary file', async () => {
+    const csvPath = join(tmpDir, 'warn-wallet.csv');
+    writeFileSync(csvPath, [
+      'address,amount,cliffOffsetMonths,lockEndOffsetMonths',
+      '0x0000000000000000000000000000000000000001,5000000,6,12',
+      '0x0000000000000000000000000000000000000002,100,6,12',
+    ].join('\n') + '\n', 'utf8');
+
+    await runLockCommand('addLocks', makeArgs({ '--csv': csvPath }));
+
+    const summary = readFileSync(join(outDir, 'safe-tx.summary.txt'), 'utf8');
+    expect(summary).toContain('0x0000000000000000000000000000000000000001');
+    expect(summary).toMatch(/\d+\.\d+% of total supply/);
+  });
+
+  it('--warn-wallet-pct run completes despite warnings', async () => {
+    const csvPath = join(tmpDir, 'warn-wallet.csv');
+    writeFileSync(csvPath, [
+      'address,amount,cliffOffsetMonths,lockEndOffsetMonths',
+      '0x0000000000000000000000000000000000000001,5000000,6,12',
+      '0x0000000000000000000000000000000000000002,100,6,12',
+    ].join('\n') + '\n', 'utf8');
+
+    await expect(
+      runLockCommand('addLocks', makeArgs({ '--csv': csvPath })),
+    ).resolves.not.toThrow();
+
+    expect(existsSync(join(outDir, 'safe-tx.json'))).toBe(true);
+    expect(existsSync(join(outDir, 'safe-tx.summary.txt'))).toBe(true);
+  });
+
+  it('threshold override warnings in summary', async () => {
+    const csvPath = join(tmpDir, 'override.csv');
+    writeFileSync(csvPath, [
+      'address,amount,cliffOffsetMonths,lockEndOffsetMonths',
+      '0x0000000000000000000000000000000000000001,100,6,12',
+    ].join('\n') + '\n', 'utf8');
+
+    await runLockCommand('addLocks', [
+      ...makeArgs({ '--csv': csvPath }),
+      '--max-total-pct', '50',
+      '--warn-wallet-pct', '5',
+    ]);
+
+    const summary = readFileSync(join(outDir, 'safe-tx.summary.txt'), 'utf8');
+    expect(summary).toContain('WARNING: --max-total-pct set to 50 (default: 10)');
+    expect(summary).toContain('WARNING: --warn-wallet-pct set to 5 (default: 1)');
+  });
+
+  it('no threshold override warnings with defaults', async () => {
+    await runLockCommand('addLocks', makeArgs());
+
+    const summary = readFileSync(join(outDir, 'safe-tx.summary.txt'), 'utf8');
+    expect(summary).not.toContain('WARNING: --max-total-pct');
+    expect(summary).not.toContain('WARNING: --warn-wallet-pct');
+  });
+
+  it('known-locks fixture: addLocks prepends entries', async () => {
+    const before = loadFixtures(knownLocksPath);
+    const beforeCount = before.length;
+
+    await runLockCommand('addLocks', makeArgs());
+
+    const after = loadFixtures(knownLocksPath);
+    expect(after.length).toBe(beforeCount + 3);
+
+    for (let i = 0; i < 3; i++) {
+      expect(after[i]!.source).toContain('addLocks:');
+    }
+
+    for (let i = 0; i < beforeCount; i++) {
+      expect(after[i + 3]!.address).toBe(before[i]!.address);
+      expect(after[i + 3]!.source).toBe(before[i]!.source);
+    }
+  });
+
+  it('known-locks fixture: addLocks source field format', async () => {
+    await runLockCommand('addLocks', makeArgs());
+
+    const after = loadFixtures(knownLocksPath);
+    for (let i = 0; i < 3; i++) {
+      expect(after[i]!.source).toMatch(/^addLocks:[0-9a-f]{12}$/);
+    }
+  });
+
+  it('known-locks fixture: addLocks entry fields', async () => {
+    await runLockCommand('addLocks', makeArgs());
+
+    const after = loadFixtures(knownLocksPath);
+    const newEntries = after.slice(0, 3);
+
+    for (const entry of newEntries) {
+      expect(entry.address).toMatch(/^0x[0-9a-fA-F]{40}$/);
+      expect(typeof entry.amount).toBe('string');
+      expect(parseFloat(entry.amount)).toBeGreaterThan(0);
+      expect(typeof entry.cliffDate).toBe('number');
+      expect(entry.cliffDate).toBeGreaterThan(0);
+      expect(typeof entry.lockEndDate).toBe('number');
+      expect(entry.lockEndDate).toBeGreaterThan(entry.cliffDate);
+    }
+  });
+
+  it('known-locks fixture: updateLocks removes then prepends', async () => {
+    await runLockCommand('addLocks', makeArgs({
+      '--csv': join(fixturesDir(), 'valid-2-wallets-with-lock.csv'),
+    }));
+    const afterAdd = loadFixtures(knownLocksPath);
+    const countAfterAdd = afterAdd.length;
+
+    await runLockCommand('updateLocks', makeArgs({
+      '--csv': join(fixturesDir(), 'valid-2-wallets-with-lock.csv'),
+    }));
+    const afterUpdate = loadFixtures(knownLocksPath);
+
+    expect(afterUpdate[0]!.source).toContain('updateLocks:');
+    expect(afterUpdate[1]!.source).toContain('updateLocks:');
+
+    const addLocksEntries = afterAdd.filter((e) => e.source.startsWith('addLocks:'));
+    const updateLocksEntries = afterUpdate.filter((e) => e.source.startsWith('updateLocks:'));
+    expect(updateLocksEntries.length).toBe(2);
+
+    expect(afterUpdate.length).toBe(countAfterAdd);
+  });
+
+  it('known-locks fixture: updateLocks source field format', async () => {
+    await runLockCommand('updateLocks', makeArgs({
+      '--csv': join(fixturesDir(), 'valid-2-wallets-with-lock.csv'),
+    }));
+
+    const after = loadFixtures(knownLocksPath);
+    const updateEntries = after.filter((e) => e.source.startsWith('updateLocks:'));
+    expect(updateEntries.length).toBeGreaterThan(0);
+    for (const entry of updateEntries) {
+      expect(entry.source).toMatch(/^updateLocks:[0-9a-f]{12}$/);
+    }
+  });
+
+  it('known-locks fixture: updateLocks preserves other entries', async () => {
+    const before = loadFixtures(knownLocksPath);
+    const updateCsvAddresses = new Set([
+      '0x073f18d260dc35d40aa5375a3ddee1616f59f5dd',
+      '0x822685e68d5d4c1c64973d831a13ebd3ed3c9b55',
+    ]);
+
+    const untouchedBefore = before.filter(
+      (e) => !updateCsvAddresses.has(e.address.toLowerCase()),
+    );
+
+    await runLockCommand('updateLocks', makeArgs({
+      '--csv': join(fixturesDir(), 'valid-2-wallets-with-lock.csv'),
+    }));
+
+    const after = loadFixtures(knownLocksPath);
+    const untouchedAfter = after.filter(
+      (e) => !e.source.startsWith('updateLocks:'),
+    );
+
+    expect(untouchedAfter.length).toBe(untouchedBefore.length);
+    for (let i = 0; i < untouchedBefore.length; i++) {
+      expect(untouchedAfter[i]!.address).toBe(untouchedBefore[i]!.address);
+      expect(untouchedAfter[i]!.amount).toBe(untouchedBefore[i]!.amount);
+      expect(untouchedAfter[i]!.source).toBe(untouchedBefore[i]!.source);
+    }
+  });
+
+  it('known-locks fixture: entries represent expected state (not on-chain)', async () => {
+    await runLockCommand('addLocks', makeArgs());
+
+    const after = loadFixtures(knownLocksPath);
+    const newEntries = after.slice(0, 3);
+
+    const expectedAddresses = [
+      '0x0000000000000000000000000000000000000001',
+      '0x0000000000000000000000000000000000000002',
+      '0x0000000000000000000000000000000000000003',
+    ];
+    const sortedNew = [...newEntries].sort((a, b) =>
+      a.address.toLowerCase().localeCompare(b.address.toLowerCase()),
+    );
+    for (let i = 0; i < expectedAddresses.length; i++) {
+      expect(sortedNew[i]!.address.toLowerCase()).toBe(expectedAddresses[i]);
+    }
+
+    expect(sortedNew[0]!.amount).toBe('100.0');
+    expect(sortedNew[1]!.amount).toBe('200.0');
+    expect(sortedNew[2]!.amount).toBe('300.0');
   });
 });

--- a/test/integration/lock-status.test.ts
+++ b/test/integration/lock-status.test.ts
@@ -3,19 +3,40 @@ import { mkdtempSync, writeFileSync, rmSync, readFileSync, existsSync } from 'no
 import { join, resolve } from 'node:path';
 import { tmpdir } from 'node:os';
 import { execFileSync } from 'node:child_process';
+import { Interface, JsonRpcProvider, getAddress, formatUnits } from 'ethers';
+import { loadFixtures, type KnownLockEntry } from '../../src/known-locks.js';
+import { getNetworkConfig } from '../../src/config.js';
 
 const RPC_URL = process.env.OMA3_OPS_RPC_URL_SEPOLIA;
 
 // Skip all integration tests if no RPC URL is configured
 const describeIf = RPC_URL ? describe : describe.skip;
 
-// Addresses for Sepolia testing.
-// Address 0x01 has no lock on Sepolia (it's a precompile).
-// For "wallet with lock" tests, set OMA3_OPS_WALLET_WITH_LOCK_SEPOLIA to a known
-// wallet address that has an active lock on the Sepolia OMALock contract.
 const WALLET_NO_LOCK = '0x0000000000000000000000000000000000000001';
 const ANOTHER_WALLET = '0x0000000000000000000000000000000000000002';
 const WALLET_WITH_LOCK = process.env.OMA3_OPS_WALLET_WITH_LOCK_SEPOLIA;
+
+const LOCK_ABI = [
+  'function getLock(address wallet_) view returns (tuple(uint40 timestamp, uint40 cliffDate, uint40 lockEndDate, uint96 amount, uint96 claimedAmount, uint96 stakedAmount, uint96 slashedAmount) lock, uint96 unlockedAmount)',
+  'function omaToken() view returns (address)',
+] as const;
+const TOKEN_ABI = ['function decimals() view returns (uint8)'] as const;
+
+const FIXTURE_PATH = resolve(process.cwd(), 'data', 'sepolia-known-locks.json');
+
+function getUniqueFixtureAddresses(): string[] {
+  const entries = loadFixtures(FIXTURE_PATH);
+  const seen = new Set<string>();
+  const addresses: string[] = [];
+  for (const entry of entries) {
+    const lower = entry.address.toLowerCase();
+    if (!seen.has(lower)) {
+      seen.add(lower);
+      addresses.push(entry.address);
+    }
+  }
+  return addresses;
+}
 
 let tmpDir: string;
 
@@ -33,6 +54,7 @@ function runLockStatus(args: string[]): string {
     encoding: 'utf8',
     env: { ...process.env, OMA3_OPS_RPC_URL_SEPOLIA: RPC_URL },
     timeout: 30000,
+    shell: true,
   });
 }
 
@@ -51,6 +73,7 @@ function runLockStatusExpectError(args: string[]): string {
       env: { ...process.env, OMA3_OPS_RPC_URL_SEPOLIA: RPC_URL },
       timeout: 30000,
       stdio: ['pipe', 'pipe', 'pipe'],
+      shell: true,
     });
     throw new Error('Expected command to fail');
   } catch (err: unknown) {
@@ -110,9 +133,10 @@ describeIf('lock-status integration', () => {
     expect(results).toHaveLength(2);
   });
 
-  it('batch via --csv', () => {
+  it('batch via --csv from fixture addresses', () => {
+    const addresses = getUniqueFixtureAddresses();
     const csvPath = join(tmpDir, 'wallets.csv');
-    writeFileSync(csvPath, `address\n${WALLET_NO_LOCK}\n${ANOTHER_WALLET}\n`, 'utf8');
+    writeFileSync(csvPath, 'address\n' + addresses.join('\n') + '\n', 'utf8');
     const outPath = join(tmpDir, 'batch.json');
 
     runLockStatus([
@@ -122,8 +146,15 @@ describeIf('lock-status integration', () => {
       '--out', outPath,
     ]);
 
-    const results = JSON.parse(readFileSync(outPath, 'utf8')) as unknown[];
-    expect(results).toHaveLength(2);
+    const results = JSON.parse(readFileSync(outPath, 'utf8')) as Array<Record<string, unknown>>;
+    expect(results).toHaveLength(addresses.length);
+
+    for (const addr of addresses) {
+      const match = results.find(
+        (r) => (r.address as string).toLowerCase() === addr.toLowerCase(),
+      );
+      expect(match, `result should include ${addr}`).toBeDefined();
+    }
   });
 
   it('--out writes JSON file', () => {
@@ -273,4 +304,115 @@ describeIfLocked('lock-status integration (hasLock: true)', () => {
     expect(locked!.amountWei).not.toBeNull();
     expect(unlocked!.amountWei).toBeNull();
   });
+});
+
+describeIf('lock-status cross-verification against direct RPC', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'lock-status-xverify-'));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('lock-status output matches direct getLock() RPC for all fixture wallets', async () => {
+    const network = getNetworkConfig('sepolia');
+    const lockIface = new Interface(LOCK_ABI);
+    const tokenIface = new Interface(TOKEN_ABI);
+    const provider = new JsonRpcProvider(RPC_URL);
+
+    const omaTokenCallData = lockIface.encodeFunctionData('omaToken', []);
+    const omaTokenResult = await provider.call({ to: network.omaLock, data: omaTokenCallData });
+    const omaToken = getAddress(lockIface.decodeFunctionResult('omaToken', omaTokenResult)[0] as string);
+
+    const decimalsResult = await provider.call({ to: omaToken, data: tokenIface.encodeFunctionData('decimals', []) });
+    const decimals = Number(tokenIface.decodeFunctionResult('decimals', decimalsResult)[0] as bigint);
+
+    const addresses = getUniqueFixtureAddresses();
+
+    const outPath = join(tmpDir, 'xverify.json');
+    runLockStatus([
+      '--wallet', ...addresses,
+      '--network', 'sepolia',
+      '--rpc-url', RPC_URL!,
+      '--out', outPath,
+    ]);
+    const cliResults = JSON.parse(readFileSync(outPath, 'utf8')) as Array<Record<string, unknown>>;
+
+    for (const addr of addresses) {
+      const cliResult = cliResults.find(
+        (r) => (r.address as string).toLowerCase() === addr.toLowerCase(),
+      );
+      expect(cliResult, `lock-status should include ${addr}`).toBeDefined();
+
+      try {
+        const callData = lockIface.encodeFunctionData('getLock', [addr]);
+        const result = await provider.call({ to: network.omaLock, data: callData });
+        const decoded = lockIface.decodeFunctionResult('getLock', result);
+        const lock = decoded[0] as {
+          timestamp: bigint; cliffDate: bigint; lockEndDate: bigint;
+          amount: bigint; claimedAmount: bigint; stakedAmount: bigint; slashedAmount: bigint;
+        };
+        const unlockedAmount = decoded[1] as bigint;
+
+        expect(cliResult!.hasLock, `${addr} hasLock`).toBe(true);
+        expect(cliResult!.timestamp, `${addr} timestamp`).toBe(Number(lock.timestamp));
+        expect(cliResult!.cliffDate, `${addr} cliffDate`).toBe(Number(lock.cliffDate));
+        expect(cliResult!.lockEndDate, `${addr} lockEndDate`).toBe(Number(lock.lockEndDate));
+        expect(cliResult!.amountWei, `${addr} amountWei`).toBe(lock.amount.toString());
+        expect(cliResult!.claimedAmountWei, `${addr} claimedAmountWei`).toBe(lock.claimedAmount.toString());
+        expect(cliResult!.stakedAmountWei, `${addr} stakedAmountWei`).toBe(lock.stakedAmount.toString());
+        expect(cliResult!.slashedAmountWei, `${addr} slashedAmountWei`).toBe(lock.slashedAmount.toString());
+        expect(cliResult!.unlockedAmountWei, `${addr} unlockedAmountWei`).toBe(unlockedAmount.toString());
+        expect(cliResult!.amount, `${addr} amount`).toBe(formatUnits(lock.amount, decimals));
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : String(err);
+        if (message.includes('NoLock') || message.includes('0xd8216464')) {
+          expect(cliResult!.hasLock, `${addr} hasLock (no lock)`).toBe(false);
+        } else {
+          throw err;
+        }
+      }
+    }
+  }, 90_000);
+
+  it('fixture immutable fields match on-chain for wallets with locks', async () => {
+    const network = getNetworkConfig('sepolia');
+    const lockIface = new Interface(LOCK_ABI);
+    const provider = new JsonRpcProvider(RPC_URL);
+
+    const entries = loadFixtures(FIXTURE_PATH);
+    const seen = new Set<string>();
+    let verifiedCount = 0;
+
+    for (const entry of entries) {
+      const lower = entry.address.toLowerCase();
+      if (seen.has(lower)) continue;
+      seen.add(lower);
+
+      try {
+        const callData = lockIface.encodeFunctionData('getLock', [entry.address]);
+        const result = await provider.call({ to: network.omaLock, data: callData });
+        const decoded = lockIface.decodeFunctionResult('getLock', result);
+        const lock = decoded[0] as {
+          amount: bigint; cliffDate: bigint; lockEndDate: bigint;
+        };
+
+        const onChainAmount = formatUnits(lock.amount, 18);
+        expect(entry.amount, `${entry.address} amount`).toBe(onChainAmount);
+        expect(entry.cliffDate, `${entry.address} cliffDate`).toBe(Number(lock.cliffDate));
+        expect(entry.lockEndDate, `${entry.address} lockEndDate`).toBe(Number(lock.lockEndDate));
+        verifiedCount++;
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : String(err);
+        if (!message.includes('NoLock') && !message.includes('0xd8216464')) {
+          throw err;
+        }
+      }
+    }
+
+    expect(verifiedCount, 'at least one fixture wallet should have an on-chain lock').toBeGreaterThan(0);
+  }, 90_000);
 });

--- a/test/integration/lock-verify-json.test.ts
+++ b/test/integration/lock-verify-json.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, writeFileSync, rmSync, readFileSync, copyFileSync } from 'node:fs';
+import { mkdtempSync, writeFileSync, rmSync, readFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { tmpdir } from 'node:os';
 import { execFileSync } from 'node:child_process';
@@ -28,6 +28,7 @@ function runVerifyJson(args: string[], env?: Record<string, string>): string {
     encoding: 'utf8',
     env: { ...process.env, OMA3_OPS_RPC_URL_SEPOLIA: RPC_URL, ...env },
     timeout: 60000,
+    shell: true,
   });
 }
 
@@ -39,11 +40,13 @@ function runVerifyJsonExpectError(args: string[]): string {
       env: { ...process.env, OMA3_OPS_RPC_URL_SEPOLIA: RPC_URL },
       timeout: 60000,
       stdio: ['pipe', 'pipe', 'pipe'],
+      shell: true,
     });
     throw new Error('Expected command to fail');
   } catch (err: unknown) {
     const error = err as ExecError;
-    return (error.stderr ?? '') + (error.stdout ?? '');
+    const output = (error.stderr ?? '') + (error.stdout ?? '');
+    return output || (error.message ?? '');
   }
 }
 
@@ -93,12 +96,23 @@ describeIf('lock-verify-json integration', () => {
   });
 
   it('RPC chain ID mismatch', () => {
-    const output = runVerifyJsonExpectError([
-      '--network', 'mainnet',
-      '--rpc-url', RPC_URL!,
-    ]);
+    const mainnetFixturePath = resolve(process.cwd(), 'data', 'mainnet-known-locks.json');
+    const savedMainnet = readFileSync(mainnetFixturePath, 'utf8');
+    try {
+      writeFileSync(mainnetFixturePath, JSON.stringify([{
+        address: '0x0000000000000000000000000000000000000001',
+        amount: '1.0', cliffDate: 1700000000, lockEndDate: 1800000000, source: 'test',
+      }]) + '\n', 'utf8');
 
-    expect(output.toLowerCase()).toContain('chain id mismatch');
+      const output = runVerifyJsonExpectError([
+        '--network', 'mainnet',
+        '--rpc-url', RPC_URL!,
+      ]);
+
+      expect(output.toLowerCase()).toContain('chain id mismatch');
+    } finally {
+      writeFileSync(mainnetFixturePath, savedMainnet, 'utf8');
+    }
   });
 
   it('empty fixture file exits cleanly', () => {
@@ -233,5 +247,114 @@ describeIf('lock-verify-json integration', () => {
     ]);
 
     expect(output).toMatch(/Results: \d+ OK, \d+ mismatch, \d+ missing/);
+  });
+
+  it('amount mismatch detected', () => {
+    const entries = JSON.parse(originalFixtureContent) as Array<Record<string, unknown>>;
+    entries[0]!.amount = '999999.0';
+    writeFileSync(fixturePath, JSON.stringify(entries, null, 2) + '\n', 'utf8');
+
+    const output = runVerifyJson([
+      '--network', 'sepolia',
+      '--rpc-url', RPC_URL!,
+      '--dry-run',
+    ]);
+
+    expect(output).toContain('MISMATCH');
+    expect(output).toContain('amount');
+  });
+
+  it('lockEndDate mismatch detected', () => {
+    const entries = JSON.parse(originalFixtureContent) as Array<Record<string, unknown>>;
+    entries[0]!.lockEndDate = 8888888;
+    writeFileSync(fixturePath, JSON.stringify(entries, null, 2) + '\n', 'utf8');
+
+    const output = runVerifyJson([
+      '--network', 'sepolia',
+      '--rpc-url', RPC_URL!,
+      '--dry-run',
+    ]);
+
+    expect(output).toContain('MISMATCH');
+    expect(output).toContain('lockEndDate');
+  });
+
+  it('multiple mismatches in one entry', () => {
+    const entries = JSON.parse(originalFixtureContent) as Array<Record<string, unknown>>;
+    entries[0]!.cliffDate = 9999999;
+    entries[0]!.lockEndDate = 8888888;
+    writeFileSync(fixturePath, JSON.stringify(entries, null, 2) + '\n', 'utf8');
+
+    const output = runVerifyJson([
+      '--network', 'sepolia',
+      '--rpc-url', RPC_URL!,
+      '--dry-run',
+    ]);
+
+    expect(output).toContain('MISMATCH');
+    expect(output).toContain('cliffDate');
+    expect(output).toContain('lockEndDate');
+  });
+
+  it('auto-fix preserves entry order', () => {
+    const entries = JSON.parse(originalFixtureContent) as Array<Record<string, unknown>>;
+    const entryCount = entries.length;
+    expect(entryCount).toBeGreaterThanOrEqual(3);
+
+    const middleIndex = Math.floor(entryCount / 2);
+    entries[middleIndex]!.cliffDate = 9999999;
+    writeFileSync(fixturePath, JSON.stringify(entries, null, 2) + '\n', 'utf8');
+
+    runVerifyJson([
+      '--network', 'sepolia',
+      '--rpc-url', RPC_URL!,
+      '--auto-fix',
+    ]);
+
+    const afterEntries = JSON.parse(readFileSync(fixturePath, 'utf8')) as Array<Record<string, unknown>>;
+
+    const okEntries = afterEntries.filter((_, i) => i !== middleIndex);
+    const originalOkEntries = JSON.parse(originalFixtureContent)
+      .filter((_: unknown, i: number) => i !== middleIndex) as Array<Record<string, unknown>>;
+
+    for (let i = 0; i < okEntries.length; i++) {
+      expect(okEntries[i]!.address, `entry ${i} address preserved`).toBe(originalOkEntries[i]!.address);
+    }
+  });
+
+  it('auto-fix removes missing and updates mismatched in one pass', () => {
+    const entries = JSON.parse(originalFixtureContent) as Array<Record<string, unknown>>;
+    const originalCount = entries.length;
+
+    entries[0]!.cliffDate = 9999999;
+
+    entries.push({
+      address: '0x0000000000000000000000000000000000000099',
+      amount: '1.0',
+      cliffDate: 1700000000,
+      lockEndDate: 1800000000,
+      source: 'test:fake',
+    });
+    writeFileSync(fixturePath, JSON.stringify(entries, null, 2) + '\n', 'utf8');
+
+    const output = runVerifyJson([
+      '--network', 'sepolia',
+      '--rpc-url', RPC_URL!,
+      '--auto-fix',
+    ]);
+
+    expect(output).toContain('MISMATCH');
+    expect(output).toContain('MISSING');
+    expect(output).toContain('Fixture updated');
+
+    const afterEntries = JSON.parse(readFileSync(fixturePath, 'utf8')) as Array<Record<string, unknown>>;
+    expect(afterEntries).toHaveLength(originalCount);
+
+    expect(afterEntries[0]!.source).toMatch(/^verified:/);
+
+    const fakeAddr = afterEntries.find(
+      (e) => (e.address as string).toLowerCase() === '0x0000000000000000000000000000000000000099',
+    );
+    expect(fakeAddr, 'fake missing entry should be removed').toBeUndefined();
   });
 });

--- a/test/unit/run-lock-command.test.ts
+++ b/test/unit/run-lock-command.test.ts
@@ -522,7 +522,7 @@ describe('runLockCommand - updateLocks preflight', () => {
 
     // Verify saveFixtures was called with the correct entries
     expect(mockSaveFixtures).toHaveBeenCalled();
-    const savedEntries = mockSaveFixtures.mock.calls[0][1] as Array<{ address: string; amount: string; source: string }>;
+    const savedEntries = mockSaveFixtures.mock.calls[0]![1] as Array<{ address: string; amount: string; source: string }>;
 
     // Find the entry for our test address
     const entry = savedEntries.find(


### PR DESCRIPTION
## Summary
 
- Add 18+ integration tests covering the remaining spec items: threshold warnings (`--max-total-pct`, `--warn-wallet-pct`), known-locks fixture lifecycle (addLocks prepend, updateLocks remove-then-prepend, source field format, entry fields, preserves other entries), cross-verification against direct RPC `getLock()`, mismatch detection/auto-fix (amount, lockEndDate, multiple fields, entry order preservation, combined remove+update), and Windows `shell: true` compatibility
- Fix TypeScript strict null check error on `mockSaveFixtures.mock.calls[0]` in `run-lock-command.test.ts` (line 525) — the only CI blocker
- Update `sepolia-known-locks.json` fixture data and `test/README.md` spec documentation
- Add `valid-2-wallets-with-lock.csv` fixture for updateLocks integration tests
 
## Test plan
- [x] All 237 unit tests pass (`npx vitest --run`)
- [x] Integration tests skip cleanly without RPC (55 skipped, 0 failed)
- [x] TypeScript typecheck passes for all test files (`npx tsc --noEmit` — only unrelated `thirdweb` import errors remain in `src/admin-wallet/`)
- [ ] Integration tests pass with `OMA3_OPS_RPC_URL_SEPOLIA` set (requires Sepolia RPC in CI or manual run)