### PR TITLE
Add guidance documentation to Github operations

### DIFF
--- a/github-governance/PULL_REQUEST_TEMPLATE.md
+++ b/github-governance/PULL_REQUEST_TEMPLATE.md
@@ -24,40 +24,68 @@
 
 - [ ] This is a self-merge
 - **Reason for emergency self-merge:**
-  <!-- e.g., production outage fix, broken deploy pipeline, launch-blocking bug -->
+  <!-- e.g., failed build blocking work, docs correction, low-risk typo -->
 - **Post-merge reviewer:** @<!-- tag someone to review after merge -->
 
 ---
 
 ### Self-Merge Policy Reference
 
-**Allowed self-merge examples:**
-- Production outage fix
-- Broken deploy pipeline
-- Launch-blocking bug
+<!--
+  SETUP (per repository): Customize the lists below before treating this
+  template as final. Keep items that apply to this repo, delete the rest,
+  and add repo-specific items as needed. The shared skeleton above stays
+  the same across OMA3 repositories; only these policy lists should differ.
+-->
+
+**Allowed self-merge examples** (trim / extend for this repo):
 - Failed build blocking work
 - Low-risk typo / config fix
+- Docs correction
 - Dependency / security patch
-- Docs correction blocking external users
-- Test-only changes
-- CI / workflow fixes
+- Test-only or fixture-only changes
+- CI / workflow fixes that do not broaden permissions
+- Production outage fix *(hosted / deployed services)*
+- Broken deploy pipeline *(hosted / deployed services)*
+- Launch-blocking bug *(product launch surfaces)*
 
-**Never self-merge (red-zone):**
-- Smart contract logic
-- Contract deployment
-- Auth / signature verification
-- Permission model changes
-- Database migrations
+**Never self-merge (red-zone)** (trim / extend for this repo):
+
+*Common*
 - Production secrets
 - GitHub Actions permission changes
 - Deployment credentials
+
+*Contracts / onchain*
+- Smart contract logic
+- Contract deployment
 - Irreversible onchain changes
+
+*Trust / identity*
+- Auth / signature verification
+- Permission model changes
 - Registry identity / trust logic
 - Attestation validity logic
+
+*Data / backend*
+- Database migrations
+
+*Protocol / MPAS*
+- Policy engine or approval-threshold changes
+- Self-approval prevention logic
+- Action Package / envelope verification
+- Credential Adapter dispatch behavior
+- Normative protocol or profile spec changes
+
+*Application plugins / bridges*
+- Plugin operation classification / impact changes
+- Governed vs pass-through tool surface changes
+- `plugin.json`, `registry-entry.json`, or `artifactDid` changes
+- Bridge dispatch or approval-gating behavior
 
 ---
 
 ### Labels
 
-Apply any that fit:
-`self-merged` · `emergency` · `post-merge-review-needed` · `launch-blocker` · `low-risk` · `security` · `red-zone` · `contract-change`
+Apply any that fit (add repo-specific labels as needed):
+`self-merged` · `emergency` · `post-merge-review-needed` · `launch-blocker` · `low-risk` · `security` · `red-zone` · `contract-change` · `plugin-change` · `bridge-change`

--- a/github-governance/README.md
+++ b/github-governance/README.md
@@ -10,7 +10,7 @@ Pragmatic branch protection and CI policy for a two-person pre-launch team.
 - Emergency self-merge exists because the team spans time zones, but it has clear boundaries.
 - Two categories. That's it. If you're debating which one a repo belongs in, it's probably `critical`.
 
-> **For contributors:** The day-to-day branching and merge process is documented in [`branching-workflow.md`](branching-workflow.md). Start there if you're looking for how to create branches, open PRs, and keep staging in sync.
+> **For contributors:** The day-to-day branching and merge process is documented in [`branching-workflow.md`](branching-workflow.md). Start there if you're looking for how to create branches, open PRs, and keep staging in sync. Testing philosophy and what-to-test guidance lives in [`testing-guidelines.md`](testing-guidelines.md). Guidance for humans using AI to evaluate PRs and issues lives in [`review-guidelines.md`](review-guidelines.md); automated reviewers may also adopt it explicitly.
 
 ## How It Works
 
@@ -23,7 +23,7 @@ Both share the same baseline rules (PR required, 1 approval, squash only, etc.).
 
 **One required check name: `ci`.** Every repo has its own `.github/workflows/ci.yml` with a single job named `ci`. What steps run inside that job depends on the repo — lint, typecheck, build, compile, whatever is real for that project. No no-op scripts.
 
-**Tests run separately.** Repos with tests have a second job named `test` in the same `ci.yml`. It runs in parallel with `ci` for visibility but is not required by the ruleset. This allows test-only PRs and test fixes to be merged without blocking on pre-existing test failures.
+**Tests run separately.** Repos with tests have a second job named `test` in the same `ci.yml`. It runs in parallel with `ci` for visibility but is not required by the ruleset. This allows test-only PRs that expose existing bugs, and changes affected by documented pre-existing failures, to merge without an automatic status-check block. A new test failure caused by a production-code change is still blocking evidence during review.
 
 **PR template.** Every repo has `.github/PULL_REQUEST_TEMPLATE.md` with a shared skeleton (risk level, summary, testing, CI status, self-merge) and a **repo-specific** self-merge policy list. The canonical copy lives in this folder as [`PULL_REQUEST_TEMPLATE.md`](PULL_REQUEST_TEMPLATE.md). When copying it into a repo, trim the catalog of allowed / red-zone examples to what applies there and add any missing items.
 
@@ -38,6 +38,8 @@ Both share the same baseline rules (PR required, 1 approval, squash only, etc.).
 | `enforce-branch-source.yml`          | Branch enforcement workflow — copied to repos that need it     |
 | `sync-main-to-staging.yml`           | Main→staging auto-sync — copied to repos that use `staging`    |
 | `branching-workflow.md`              | Contributor guide — branching, merging, and sync process       |
+| `testing-guidelines.md`              | Contributor guide — what, how, and how much to test            |
+| `review-guidelines.md`               | AI-assisted review guide — verdicts, scope, and follow-ups     |
 
 ## Repository Categories
 
@@ -109,7 +111,9 @@ The `ci` job contains only steps that are real for that repo — lint, typecheck
 Repos with tests have a separate `test` job in the same workflow file. It runs in parallel for visibility but is **not required** by the ruleset. This avoids blocking PRs when:
 - The test engineer submits tests that expose implementation bugs
 - Pre-existing test failures haven't been fixed yet
-- A developer needs to merge partial work before all tests pass
+- A test or fixture improvement is useful independently of an existing implementation fix
+
+This ruleset choice does not make test results irrelevant. Reviewers should treat a new failure caused by a production-code change as blocking evidence of a regression. See [`testing-guidelines.md`](testing-guidelines.md) for the full distinction.
 
 ## Branch Enforcement
 
@@ -227,7 +231,7 @@ We are a two-person team. Requiring two reviewers would mean every PR needs both
 
 ### Why tests are not required
 
-Tests run in CI for visibility but don't block merges. This avoids a chicken-and-egg problem: the test engineer writes tests that expose implementation bugs, but can't merge the tests until the bugs are fixed. Separating the `test` job from the required `ci` job lets both roles work independently.
+The `test` job is visible but is not an automatically required merge check. This avoids a chicken-and-egg problem: the test engineer writes tests that expose implementation bugs, but can't merge the tests until the bugs are fixed. Separating the `test` job from the required `ci` job lets both roles work independently while still allowing reviewers to block a production-code regression supported by a newly failing test.
 
 ## Updating Rulesets
 

--- a/github-governance/README.md
+++ b/github-governance/README.md
@@ -36,6 +36,7 @@ Both share the same baseline rules (PR required, 1 approval, squash only, etc.).
 | `standard.json`                      | GitHub ruleset for standard repos — import via GitHub UI       |
 | `PULL_REQUEST_TEMPLATE.md`           | Canonical PR template — copied to each repo's `.github/`       |
 | `enforce-branch-source.yml`          | Branch enforcement workflow — copied to repos that need it     |
+| `sync-main-to-staging.yml`           | Main→staging auto-sync — copied to repos that use `staging`    |
 | `branching-workflow.md`              | Contributor guide — branching, merging, and sync process       |
 
 ## Repository Categories
@@ -132,7 +133,9 @@ The `check-source` job is **not** added to the required status checks in `critic
 
 ## Main → Staging Auto-Sync
 
-Every repo has a workflow (`.github/workflows/sync-main-to-staging.yml`) that automatically merges `main` back into `staging` after any push to `main`. This prevents branch divergence.
+Repos that use a `staging` branch should have a workflow (`.github/workflows/sync-main-to-staging.yml`) that automatically merges `main` back into `staging` after any push to `main`. This prevents branch divergence. Repos without a `staging` branch do not need this workflow.
+
+**Canonical workflow file:** [`sync-main-to-staging.yml`](sync-main-to-staging.yml) in this folder. Copy to `.github/workflows/` in staging repos.
 
 For details on why this matters, the manual fallback, and the full branching process, see [`branching-workflow.md`](branching-workflow.md).
 
@@ -141,7 +144,7 @@ For details on why this matters, the manual fallback, and the full branching pro
 For a new repository:
 
 1. Add `.github/workflows/ci.yml` with a job named `ci`. Include only steps that are real for the repo — lint if it has a linter, typecheck if it's TypeScript, build if it produces output, compile if it's Solidity. No no-op steps. If the repo has tests, add a separate `test` job in the same file (not required by the ruleset).
-2. If the new repository uses a staging branch, add `.github/workflows/sync-main-to-staging.yml` (copy from any repo that already has it). This auto-syncs `main` back into `staging` after every merge to `main`, preventing branch divergence.
+2. If the new repository uses a staging branch, add `.github/workflows/sync-main-to-staging.yml` (copy from this folder). This auto-syncs `main` back into `staging` after every merge to `main`, preventing branch divergence.
 3. Add `.github/PULL_REQUEST_TEMPLATE.md` (copy from this folder). Customize the Self-Merge Policy Reference lists for that repo — keep applicable items, delete the rest, add repo-specific ones.
 4. Push the branch and open a PR so the `ci` check runs once.
 5. Confirm the PR shows a check named exactly `ci`.
@@ -171,12 +174,12 @@ A repo is considered hardened when all of the following are in place:
 | Requirement                         | Description                                                   |
 | ----------------------------------- | ------------------------------------------------------------- |
 | `.github/workflows/ci.yml`          | CI workflow with a job named `ci`                             |
-| `.github/workflows/sync-main-to-staging.yml` | Auto-syncs main back into staging after merges       |
 | `.github/PULL_REQUEST_TEMPLATE.md`  | Standardized PR template                                      |
 | Ruleset imported                    | `critical.json` or `standard.json` imported via GitHub UI     |
 | Ruleset enforcement active          | Enforcement set to Active in repo settings                    |
 | Bypass configured                   | `maintainers` team set as bypass actor (pull request only)    |
 | Branch enforcement (if applicable)  | `enforce-branch-source.yml` added for auto-deploying repos    |
+| Main→staging sync (if applicable)   | `sync-main-to-staging.yml` added for repos that use `staging` |
 
 ### Hardening Status
 

--- a/github-governance/README.md
+++ b/github-governance/README.md
@@ -10,6 +10,8 @@ Pragmatic branch protection and CI policy for a two-person pre-launch team.
 - Emergency self-merge exists because the team spans time zones, but it has clear boundaries.
 - Two categories. That's it. If you're debating which one a repo belongs in, it's probably `critical`.
 
+> **For contributors:** The day-to-day branching and merge process is documented in [`branching-workflow.md`](branching-workflow.md). Start there if you're looking for how to create branches, open PRs, and keep staging in sync.
+
 ## How It Works
 
 **Two ruleset JSON files.** Import one per repo. Never edit them per-repo.
@@ -27,13 +29,14 @@ Both share the same baseline rules (PR required, 1 approval, squash only, etc.).
 
 ## Files in This Folder
 
-| File                                 | Purpose                                                    |
-| ------------------------------------ | ---------------------------------------------------------- |
-| `README.md`                          | This document                                              |
-| `critical.json`                      | GitHub ruleset for critical repos — import via GitHub UI   |
-| `standard.json`                      | GitHub ruleset for standard repos — import via GitHub UI   |
-| `PULL_REQUEST_TEMPLATE.md`           | Canonical PR template — copied to each repo's `.github/`   |
-| `enforce-branch-source.yml`          | Branch enforcement workflow — copied to repos that need it |
+| File                                 | Purpose                                                        |
+| ------------------------------------ | -------------------------------------------------------------- |
+| `README.md`                          | This document                                                  |
+| `critical.json`                      | GitHub ruleset for critical repos — import via GitHub UI       |
+| `standard.json`                      | GitHub ruleset for standard repos — import via GitHub UI       |
+| `PULL_REQUEST_TEMPLATE.md`           | Canonical PR template — copied to each repo's `.github/`       |
+| `enforce-branch-source.yml`          | Branch enforcement workflow — copied to repos that need it     |
+| `branching-workflow.md`              | Contributor guide — branching, merging, and sync process       |
 
 ## Repository Categories
 
@@ -127,18 +130,25 @@ Some repos restrict which branches can open PRs to `main`. This is enforced by a
 
 The `check-source` job is **not** added to the required status checks in `critical.json`. It runs as a separate workflow and is informational by default. To make it blocking, add `"check-source"` to `required_status_checks` in the repo's imported ruleset.
 
+## Main → Staging Auto-Sync
+
+Every repo has a workflow (`.github/workflows/sync-main-to-staging.yml`) that automatically merges `main` back into `staging` after any push to `main`. This prevents branch divergence.
+
+For details on why this matters, the manual fallback, and the full branching process, see [`branching-workflow.md`](branching-workflow.md).
+
 ## Setup Order
 
 For a new repository:
 
 1. Add `.github/workflows/ci.yml` with a job named `ci`. Include only steps that are real for the repo — lint if it has a linter, typecheck if it's TypeScript, build if it produces output, compile if it's Solidity. No no-op steps. If the repo has tests, add a separate `test` job in the same file (not required by the ruleset).
-2. Add `.github/PULL_REQUEST_TEMPLATE.md` (copy from this folder).
-3. Push the branch and open a PR so the `ci` check runs once.
-4. Confirm the PR shows a check named exactly `ci`.
-5. Go to the repo → **Settings** → **Rules** → **Rulesets** → **New ruleset** → **Import a ruleset**.
-6. Upload `critical.json` or `standard.json`.
-7. Set enforcement to **Active**.
-8. Update the repository tables in this README.
+2. If the new repository uses a staging branch, add `.github/workflows/sync-main-to-staging.yml` (copy from any repo that already has it). This auto-syncs `main` back into `staging` after every merge to `main`, preventing branch divergence.
+3. Add `.github/PULL_REQUEST_TEMPLATE.md` (copy from this folder).
+4. Push the branch and open a PR so the `ci` check runs once.
+5. Confirm the PR shows a check named exactly `ci`.
+6. Go to the repo → **Settings** → **Rules** → **Rulesets** → **New ruleset** → **Import a ruleset**.
+7. Upload `critical.json` or `standard.json`.
+8. Set enforcement to **Active**.
+9. Update the repository tables in this README.
 
 ## Emergency Self-Merge Policy
 
@@ -185,6 +195,7 @@ A repo is considered hardened when all of the following are in place:
 | Requirement                         | Description                                                   |
 | ----------------------------------- | ------------------------------------------------------------- |
 | `.github/workflows/ci.yml`          | CI workflow with a job named `ci`                             |
+| `.github/workflows/sync-main-to-staging.yml` | Auto-syncs main back into staging after merges       |
 | `.github/PULL_REQUEST_TEMPLATE.md`  | Standardized PR template                                      |
 | Ruleset imported                    | `critical.json` or `standard.json` imported via GitHub UI     |
 | Ruleset enforcement active          | Enforcement set to Active in repo settings                    |

--- a/github-governance/README.md
+++ b/github-governance/README.md
@@ -25,7 +25,7 @@ Both share the same baseline rules (PR required, 1 approval, squash only, etc.).
 
 **Tests run separately.** Repos with tests have a second job named `test` in the same `ci.yml`. It runs in parallel with `ci` for visibility but is not required by the ruleset. This allows test-only PRs and test fixes to be merged without blocking on pre-existing test failures.
 
-**PR template.** Every repo has `.github/PULL_REQUEST_TEMPLATE.md` with risk level, summary, testing, CI status, and self-merge sections. The canonical copy lives in this folder as [`PULL_REQUEST_TEMPLATE.md`](PULL_REQUEST_TEMPLATE.md).
+**PR template.** Every repo has `.github/PULL_REQUEST_TEMPLATE.md` with a shared skeleton (risk level, summary, testing, CI status, self-merge) and a **repo-specific** self-merge policy list. The canonical copy lives in this folder as [`PULL_REQUEST_TEMPLATE.md`](PULL_REQUEST_TEMPLATE.md). When copying it into a repo, trim the catalog of allowed / red-zone examples to what applies there and add any missing items.
 
 ## Files in This Folder
 
@@ -142,7 +142,7 @@ For a new repository:
 
 1. Add `.github/workflows/ci.yml` with a job named `ci`. Include only steps that are real for the repo — lint if it has a linter, typecheck if it's TypeScript, build if it produces output, compile if it's Solidity. No no-op steps. If the repo has tests, add a separate `test` job in the same file (not required by the ruleset).
 2. If the new repository uses a staging branch, add `.github/workflows/sync-main-to-staging.yml` (copy from any repo that already has it). This auto-syncs `main` back into `staging` after every merge to `main`, preventing branch divergence.
-3. Add `.github/PULL_REQUEST_TEMPLATE.md` (copy from this folder).
+3. Add `.github/PULL_REQUEST_TEMPLATE.md` (copy from this folder). Customize the Self-Merge Policy Reference lists for that repo — keep applicable items, delete the rest, add repo-specific ones.
 4. Push the branch and open a PR so the `ci` check runs once.
 5. Confirm the PR shows a check named exactly `ci`.
 6. Go to the repo → **Settings** → **Rules** → **Rulesets** → **New ruleset** → **Import a ruleset**.
@@ -158,33 +158,9 @@ For a new repository:
 
 **How:** Open a normal PR. CI must pass. Fill out the self-merge section in the PR template. Tag a post-merge reviewer. Apply the `self-merged` and `post-merge-review-needed` labels.
 
-### Allowed self-merge examples
+### Allowed / never lists are per repository
 
-- Production outage fix
-- Broken deploy pipeline
-- Launch-blocking bug
-- Failed build blocking work
-- Low-risk typo / config fix
-- Dependency / security patch
-- Docs correction blocking external users
-- Test-only changes
-- CI / workflow fixes
-
-### Never self-merge (red-zone)
-
-These changes require a second pair of eyes regardless of urgency:
-
-- Smart contract logic
-- Contract deployment
-- Auth / signature verification
-- Permission model changes
-- Database migrations
-- Production secrets
-- GitHub Actions permission changes
-- Deployment credentials
-- Irreversible onchain changes
-- Registry identity / trust logic
-- Attestation validity logic
+The PR template skeleton is shared. The **Allowed self-merge** and **Never self-merge (red-zone)** lists are customized per repo from the catalog in [`PULL_REQUEST_TEMPLATE.md`](PULL_REQUEST_TEMPLATE.md). Contributors follow the lists in that repository's `.github/PULL_REQUEST_TEMPLATE.md`.
 
 If a red-zone change is truly urgent and no reviewer is available, escalate — don't self-merge.
 

--- a/github-governance/branching-workflow.md
+++ b/github-governance/branching-workflow.md
@@ -41,7 +41,7 @@ If this returns nothing you can proceed.  If this shows any commits, staging is 
 
 1. Open a PR: `staging → main`
 2. Reviewer approves and merges it.
-3. **The person who merges immediately runs the sync step:**
+3. **Confirm that `main` is synced back into `staging`.** Repositories with `sync-main-to-staging.yml` do this automatically. If the workflow is not installed or fails, the person who merged runs the manual fallback immediately:
 
 ```bash
 git fetch origin
@@ -53,7 +53,7 @@ git push origin staging
 
 This gives `staging` the squash commit that GitHub created on `main`. Until this is done, `origin/staging` is diverged and everyone branching off it will have problems.
 
-> **Note:** Staging repos with `sync-main-to-staging.yml` handle this automatically after the merge button is clicked. The canonical workflow lives in this folder — copy it into `.github/workflows/` for repos that use `staging`. If the Action is installed, the manual step is a fallback in case it fails.
+> **Note:** The canonical workflow lives in this folder — copy it into `.github/workflows/` for repos that use `staging`.
 
 > **CI caveat:** Pushes made with `GITHUB_TOKEN` (including the auto-sync Action) don't trigger downstream workflows. CI won't run on `staging` after an auto-sync. This is fine since staging isn't gated by status checks — just don't assume CI ran there.
 
@@ -63,7 +63,7 @@ This gives `staging` the squash commit that GitHub created on `main`. Until this
 
 - **Don't branch off `main`** — ever, for any reason.
 - **Don't skip the sync step** after merging into `main`. This is the single most common cause of divergence.
-- **Don't push directly to `main` or `staging`** — all changes go through PRs.
+- **Don't push feature changes directly to `main` or `staging`** — all changes go through PRs. The documented `main` → `staging` sync, performed by the workflow or its manual fallback, is the only direct-push exception.
 - **Don't branch off a local `staging` you haven't fetched** — always `git fetch origin` first.
 - **Don't self-merge by default** — prefer reviewer merge. Use emergency self-merge only when the other reviewer is unavailable and the change fits the repo's allowed list (see PR template / [`README.md`](README.md)).
 

--- a/github-governance/branching-workflow.md
+++ b/github-governance/branching-workflow.md
@@ -12,7 +12,7 @@ When a PR merges into `main`, GitHub creates a merge commit that only exists on 
 
 ```bash
 git fetch origin
-git checkout -b feature/your-branch-name origin/staging --no-track
+git checkout -b feat/your-branch-name origin/staging --no-track
 ```
 
 Always branch from `origin/staging` — never from a stale local branch, never from `main`.

--- a/github-governance/branching-workflow.md
+++ b/github-governance/branching-workflow.md
@@ -2,7 +2,7 @@
 
 ## Why This Matters
 
-When a PR merges into `main`, GitHub creates a merge commit that only exists on `main`. If nobody merges `main` back into `staging` afterward, the two branches diverge — and every future PR from `staging → main` will be blocked or require manual conflict resolution.
+When a PR merges into `main`, GitHub creates a squash commit that only exists on `main` (our rulesets enforce squash-only merges with linear history). Because this squash commit has no parent relationship to `staging`, the two branches diverge if nobody merges `main` back into `staging` afterward — and every future PR from `staging → main` will be blocked or require manual conflict resolution.
 
 **The sync step after every merge into main is what keeps this workflow working.** Skip it once and everyone downstream is building on diverged state.
 
@@ -51,9 +51,11 @@ git merge origin/main --no-edit
 git push origin staging
 ```
 
-This gives `staging` the merge commit that GitHub created on `main`. Until this is done, `origin/staging` is diverged and everyone branching off it will have problems.
+This gives `staging` the squash commit that GitHub created on `main`. Until this is done, `origin/staging` is diverged and everyone branching off it will have problems.
 
 > **Note:** Staging repos with `sync-main-to-staging.yml` handle this automatically after the merge button is clicked. The canonical workflow lives in this folder — copy it into `.github/workflows/` for repos that use `staging`. If the Action is installed, the manual step is a fallback in case it fails.
+
+> **CI caveat:** Pushes made with `GITHUB_TOKEN` (including the auto-sync Action) don't trigger downstream workflows. CI won't run on `staging` after an auto-sync. This is fine since staging isn't gated by status checks — just don't assume CI ran there.
 
 ---
 

--- a/github-governance/branching-workflow.md
+++ b/github-governance/branching-workflow.md
@@ -1,0 +1,79 @@
+# Branching & Merge Workflow
+
+## Why This Matters
+
+When a PR merges into `main`, GitHub creates a merge commit that only exists on `main`. If nobody merges `main` back into `staging` afterward, the two branches diverge — and every future PR from `staging → main` will be blocked or require manual conflict resolution.
+
+**The sync step after every merge into main is what keeps this workflow working.** Skip it once and everyone downstream is building on diverged state.
+
+---
+
+## Starting New Work
+
+```bash
+git fetch origin
+git checkout -b feature/your-branch-name origin/staging --no-track
+```
+
+Always branch from `origin/staging` — never from a stale local branch, never from `main`.
+
+**Optional safety check** — verify staging isn't behind main before you start:
+
+```bash
+git log --oneline origin/staging..origin/main
+```
+
+If this returns nothing you can proceed.  If this shows any commits, staging is behind main and someone forgot to sync. Don't start work until it's resolved — either do the sync yourself or flag it to the team.
+
+---
+
+## Opening a PR
+
+- Target: `staging`
+- All feature work, bug fixes, and improvements go into `staging` first.
+- The reviewer approves and merges the PR. The author does not merge their own PR.
+
+**Multiple PRs targeting staging:** Just merge them one at a time. After PR #1 merges, GitHub may show PR #2 as "out of date" — click "Update branch" in the GitHub UI or have the author rebase. No manual sync step is needed between staging PRs. The sync step only applies after merges into `main`.
+
+---
+
+## Promoting Staging to Production
+
+1. Open a PR: `staging → main`
+2. Reviewer approves and merges it.
+3. **The person who merges immediately runs the sync step:**
+
+```bash
+git fetch origin
+git checkout staging
+git pull origin staging
+git merge origin/main --no-edit
+git push origin staging
+```
+
+This gives `staging` the merge commit that GitHub created on `main`. Until this is done, `origin/staging` is diverged and everyone branching off it will have problems.
+
+> **Note:** Repos with the `sync-main-to-staging.yml` GitHub Action handle this automatically — the sync happens in the background after the merge button is clicked. Check if your repo has this Action installed. If it does, the manual step is a fallback in case the Action fails.
+
+---
+
+## Don't
+
+- **Don't branch off `main`** — ever, for any reason.
+- **Don't skip the sync step** after merging into `main`. This is the single most common cause of divergence.
+- **Don't push directly to `main` or `staging`** — all changes go through PRs.
+- **Don't branch off a local `staging` you haven't fetched** — always `git fetch origin` first.
+- **Don't merge your own PR** — the reviewer approves and merges.
+
+---
+
+## Hotfixes
+
+Hotfixes also go through staging first. Only `staging` and `hotfix/*` branches can PR into `main` (enforced by GitHub Action in repos with branch enforcement).
+
+1. `git fetch origin && git checkout -b hotfix/description origin/staging --no-track`
+2. PR into `staging`, get review, merge.
+3. PR `staging → main`, get review, merge.
+4. Sync step runs (manually or via Action).
+
+The sync step still applies — a hotfix merged into `main` creates the same divergence risk as any other merge.

--- a/github-governance/branching-workflow.md
+++ b/github-governance/branching-workflow.md
@@ -31,7 +31,7 @@ If this returns nothing you can proceed.  If this shows any commits, staging is 
 
 - Target: `staging`
 - All feature work, bug fixes, and improvements go into `staging` first.
-- The reviewer approves and merges the PR. The author does not merge their own PR.
+- Prefer that the reviewer approves and merges. Emergency self-merge is allowed for maintainers when the other reviewer is unavailable — follow the Self-Merge section in the PR template and the policy in [`README.md`](README.md).
 
 **Multiple PRs targeting staging:** Just merge them one at a time. After PR #1 merges, GitHub may show PR #2 as "out of date" — click "Update branch" in the GitHub UI or have the author rebase. No manual sync step is needed between staging PRs. The sync step only applies after merges into `main`.
 
@@ -53,7 +53,7 @@ git push origin staging
 
 This gives `staging` the merge commit that GitHub created on `main`. Until this is done, `origin/staging` is diverged and everyone branching off it will have problems.
 
-> **Note:** Repos with the `sync-main-to-staging.yml` GitHub Action handle this automatically — the sync happens in the background after the merge button is clicked. Check if your repo has this Action installed. If it does, the manual step is a fallback in case the Action fails.
+> **Note:** Staging repos with `sync-main-to-staging.yml` handle this automatically after the merge button is clicked. The canonical workflow lives in this folder — copy it into `.github/workflows/` for repos that use `staging`. If the Action is installed, the manual step is a fallback in case it fails.
 
 ---
 
@@ -63,17 +63,19 @@ This gives `staging` the merge commit that GitHub created on `main`. Until this 
 - **Don't skip the sync step** after merging into `main`. This is the single most common cause of divergence.
 - **Don't push directly to `main` or `staging`** — all changes go through PRs.
 - **Don't branch off a local `staging` you haven't fetched** — always `git fetch origin` first.
-- **Don't merge your own PR** — the reviewer approves and merges.
+- **Don't self-merge by default** — prefer reviewer merge. Use emergency self-merge only when the other reviewer is unavailable and the change fits the repo's allowed list (see PR template / [`README.md`](README.md)).
 
 ---
 
 ## Hotfixes
 
-Hotfixes also go through staging first. Only `staging` and `hotfix/*` branches can PR into `main` (enforced by GitHub Action in repos with branch enforcement).
+Hotfixes follow the same staging path as normal work. Only `staging` and `hotfix/*` branches can PR into `main` (enforced by GitHub Action in repos with branch enforcement).
 
 1. `git fetch origin && git checkout -b hotfix/description origin/staging --no-track`
 2. PR into `staging`, get review, merge.
 3. PR `staging → main`, get review, merge.
 4. Sync step runs (manually or via Action).
+
+If a reviewer is unavailable and the fix cannot wait, a maintainer may self-merge either PR under the emergency self-merge policy — fill out the Self-Merge section, tag a post-merge reviewer, and apply the usual labels. Red-zone changes still require a second pair of eyes (or escalation).
 
 The sync step still applies — a hotfix merged into `main` creates the same divergence risk as any other merge.

--- a/github-governance/review-guidelines.md
+++ b/github-governance/review-guidelines.md
@@ -1,0 +1,115 @@
+# AI-Assisted Code Review Guidelines
+
+Guidance for humans using AI tools to evaluate PRs and triage issues across OMA3 repositories. Automated reviewers may also adopt these instructions explicitly.
+
+Human reviewers have judgment and context — these rules are not for them. This document exists because AI reviewers (Cursor, Copilot, automated bots) tend to be pedantic, treating every observation as a blocker regardless of its actual impact. These guidelines correct that behavior.
+
+---
+
+## Core Rule
+
+**Make a proportional decision.** Evaluate whether the PR delivers on its stated goal without introducing harm. Then give a clear recommended verdict — approve, request changes, or comment — with brief reasoning.
+
+Don't block PRs over minor issues. Don't rubber-stamp PRs that have real problems. The job is to distinguish between the two.
+
+A PR should be approved when the available evidence shows that it accomplishes its stated goal without introducing a blocking issue. Non-blocking observations should not be presented as reasons to delay the merge.
+
+---
+
+## When to Block (Request Changes)
+
+Block a PR only when merging it would cause concrete harm. Examples include:
+
+- **Correctness bug** — the code doesn't do what the PR claims, or it introduces a regression.
+- **Security issue** — secrets exposed, auth bypassed, injection vulnerability, unsafe data handling.
+- **Breaking change** — API contract broken, migration missing, downstream consumers will fail.
+- **Data loss risk** — destructive operation without safeguard, irreversible state change.
+- **Reliability or performance regression** — the change can cause an outage, resource exhaustion, or material degradation under realistic use.
+- **Required validation broken** — required checks fail, or the PR causes a previously passing relevant test to fail.
+- **Governance violation** — the change bypasses a repository-specific safety rule or required approval path.
+
+A blocking finding must identify the changed code, a realistic triggering condition, and the resulting impact. Lack of confidence by itself is not a finding. If a safety-critical claim cannot be verified because necessary evidence is missing, state exactly what evidence is needed and why.
+
+## What Is Never Blocking
+
+These are valid observations but must not prevent a merge. Track them separately only when they are material enough to prioritize:
+
+- Style preferences or naming nits
+- Suggestions to refactor code that the PR didn't introduce
+- Missing tests for edge cases that aren't on the critical path
+- "While you're here, you could also..." scope expansion
+- Minor readability improvements
+- Incidental copy or wording suggestions (unless the text is a functional, accessibility, protocol, or compliance requirement)
+- Inconsistency with a pattern used elsewhere in the codebase (unless it causes a bug)
+
+---
+
+## Track Material Follow-Ups Without Blocking
+
+When you notice a material improvement that isn't blocking, first check whether it is already tracked. If it is new and you have permission, create a follow-up issue rather than requesting changes on the current PR. A follow-up issue must:
+
+1. Describe the specific improvement
+2. Reference the file and line (or PR number where you noticed it)
+3. Stand on its own — someone should be able to fix it without context from the original PR
+
+Do not create issues for every nit or speculative concern. If you cannot create an issue, include the item in a clearly labeled **Non-blocking follow-ups** section so a human can decide whether to track it.
+
+---
+
+## Closing Issues
+
+### Match the PR to the issue's stated criteria
+
+An issue defines a problem. A PR closes that issue when it solves the stated problem and the changed behavior does not introduce a blocking issue. The PR does not need to:
+
+- Fix tangential things the reviewer notices in adjacent code
+- Achieve perfect coverage of the new code
+- Refactor surrounding code
+- Anticipate future requirements not mentioned in the issue
+
+If the issue says "add pagination to /users" and the PR adds working pagination, the issue is resolved.
+
+### Don't block a PR because it doesn't fix something it never claimed to fix
+
+If a PR closes issue #42 but you notice an unrelated problem in the same file, file a new issue. Don't hold the PR open until the unrelated problem is also fixed.
+
+### Don't reopen closed issues for minor follow-ups
+
+If an issue was closed by a merged PR and a minor gap is noticed later, open a new issue. Reopening conflates "this doesn't work" with "this could be improved."
+
+---
+
+## Proportionality
+
+Match review depth to the nature and risk of the change. Size is a useful signal, but it does not determine the verdict: a five-line authorization change can be riskier than a thousand-line fixture update.
+
+| Change profile | Review emphasis |
+|---|---|
+| Copy, comments, formatting | Confirm the diff is limited to non-functional changes |
+| Small localized fix | Verify the reported failure, the fix, and regression risk |
+| Feature or broad refactor | Trace affected flows, contracts, failure handling, and tests |
+| Generated or repetitive changes | Sample representative sections and validate generator assumptions |
+| Security, auth, data, infrastructure, or onchain | Review thoroughly and require evidence for safety-critical assumptions |
+| Large or difficult-to-review diff | Identify high-risk areas first; request decomposition only when the change cannot be reviewed reliably |
+
+Review depth does not determine the verdict. Approve only after finding no blocking issue. Request changes only for a specific, evidence-backed risk or for evidence necessary to validate a safety-critical claim.
+
+A small bug fix does not warrant 20 comments about the surrounding file's structure. A large test-only PR does not need every assertion audited, but representative tests should be checked to confirm they exercise real behavior and fail when that behavior is broken.
+
+---
+
+## Scope
+
+A PR's intended outcome is defined by its title, description, and linked issue. Every behavior added or changed by the diff is in review scope, including changes not mentioned in the description.
+
+Do not expand the PR's success criteria to include unrelated pre-existing problems or adjacent improvements. Track those separately. However, an undocumented change introduced by the PR is not protected from review merely because the author did not mention it.
+
+---
+
+## Tone
+
+- Be direct. "This will crash when `items` is empty" — not "Have you considered what might happen if..."
+- Base claims on the diff, repository behavior, and available checks. State uncertainty instead of inventing facts.
+- Explain the triggering condition and impact. Offer a practical solution when one is clear.
+- Don't pile on. One comment per issue is enough.
+- Distinguish clearly between blocking concerns and optional follow-ups. Track material follow-ups without turning minor observations into issue noise.

--- a/github-governance/sync-main-to-staging.yml
+++ b/github-governance/sync-main-to-staging.yml
@@ -1,0 +1,33 @@
+name: Sync main → staging
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Merge main into staging
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout staging
+          git merge origin/main --no-edit || {
+            git merge --abort
+            gh issue create \
+              --title "⚠️ Auto-sync failed: main → staging has conflicts" \
+              --body "The automatic merge of main into staging failed due to conflicts. Please resolve manually:\n\n\`\`\`bash\ngit fetch origin\ngit checkout staging\ngit merge origin/main\n# resolve conflicts\ngit push origin staging\n\`\`\`" \
+              --label "bug"
+            exit 1
+          }
+          git push origin staging
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/github-governance/sync-main-to-staging.yml
+++ b/github-governance/sync-main-to-staging.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches: [main]
 
+concurrency:
+  group: sync-main-to-staging
+  cancel-in-progress: false
+
 jobs:
   sync:
     runs-on: ubuntu-latest
@@ -24,8 +28,7 @@ jobs:
             git merge --abort
             gh issue create \
               --title "⚠️ Auto-sync failed: main → staging has conflicts" \
-              --body "The automatic merge of main into staging failed due to conflicts. Please resolve manually:\n\n\`\`\`bash\ngit fetch origin\ngit checkout staging\ngit merge origin/main\n# resolve conflicts\ngit push origin staging\n\`\`\`" \
-              --label "bug"
+              --body "$(printf 'The automatic merge of main into staging failed due to conflicts. Please resolve manually:\n\n```bash\ngit fetch origin\ngit checkout staging\ngit merge origin/main\n# resolve conflicts\ngit push origin staging\n```\n')"
             exit 1
           }
           git push origin staging

--- a/github-governance/testing-guidelines.md
+++ b/github-governance/testing-guidelines.md
@@ -1,0 +1,205 @@
+# Testing Guidelines
+
+Pragmatic cross-repository guidance for what, how, and how much to test. Use each repository's documented test framework, commands, and more specific test requirements.
+
+Examples below use TypeScript and frontend tests for concreteness, but the principles apply to services, libraries, contracts, scripts, and documentation tooling as well.
+
+## Philosophy
+
+- Tests exist to catch regressions and validate behavior. They are not a coverage number.
+- Test what the user sees and what the system does — not how it's wired internally.
+- One meaningful test that proves a behavior works is worth more than five that assert mock plumbing.
+- AI-generated test PRs must meet the same quality bar as hand-written code. Volume alone is not a contribution.
+
+---
+
+## What to Test
+
+### High value — always test these
+
+**User-facing behavior through interactions.** Click submit, fill a form, trigger a state change — assert the outcome the user would observe.
+
+```ts
+// Good: tests what happens from the user's perspective
+fireEvent.click(screen.getByRole('button', { name: /submit/i }))
+await waitFor(() => {
+  expect(screen.getByText(/success/i)).toBeInTheDocument()
+})
+```
+
+**Conditional rendering that gates functionality.** If a prop or state determines whether something appears or is accessible, test both sides.
+
+```ts
+// Plan is free → Upgrade button appears
+// Plan is paid → Upgrade button does not appear
+```
+
+**State transitions.** Loading → loaded, loading → error, dialog open → submit → close.
+
+**API integration (happy path + representative failures).** Verify the unit uses the right endpoint and contract, then test distinct failure behaviors. One representative failure may be enough when all failures share a path; security- or workflow-sensitive failures may need separate coverage.
+
+**Pure function logic.** For utility functions, test inputs and outputs directly — boundary values, invalid inputs, representative cases.
+
+### Low value — skip or minimize these
+
+**Incidental UI copy.** Don't assert precise wording when the wording is not part of the behavior. Prefer role-based queries or a stable semantic match so routine copy edits do not break tests.
+
+```ts
+// Bad — breaks when copy changes
+expect(screen.getByText('Ownership verification did not succeed yet.')).toBeInTheDocument()
+
+// Better — tests that feedback exists without coupling to exact words
+expect(screen.getByRole('alert')).toBeInTheDocument()
+// Or with a loose match:
+expect(screen.getByText(/verification.*failed/i)).toBeInTheDocument()
+```
+
+Exact text is appropriate when the wording is itself a contract: accessibility names, protocol-defined values, compliance language, commands users must copy, or distinct errors that require different user action.
+
+**CSS classes, Tailwind utilities, styling details.** These are visual concerns, not behavioral. If the design system changes, every test breaks for no functional reason.
+
+```ts
+// Bad
+expect(element).toHaveClass('text-destructive')
+
+// Instead, test the condition that triggers the styling:
+// "When quota is exhausted, the count shows zero"
+expect(screen.getByText('0')).toBeInTheDocument()
+```
+
+**Mock wiring without an observable contract.** Testing only that a mock function was called often proves wiring rather than useful behavior. Prefer asserting on the resulting output or state when possible.
+
+```ts
+// Bad — proves nothing about the UI
+expect(mockGetControllerConfirmation).toHaveBeenCalledWith('did:web:example.com')
+
+// Better — proves the data reached the screen
+expect(screen.getByText('Authorized')).toBeInTheDocument()
+```
+
+Interaction assertions are appropriate when the interaction is the contract: API payloads, callbacks, navigation, persisted data, emitted events, authorization checks, and other external side effects.
+
+**Exhaustive permutations of the same shared pattern.** If fallback behavior is centralized in a shared implementation, test it thoroughly there and use representative integration coverage elsewhere. If several components implement the fallback independently, one component's test does not prove that the others work.
+
+**Third-party component internals.** Don't retest that Radix Dialog implements `open={true}`. Do test your integration with it when configuration, accessibility, or application state could be wrong.
+
+---
+
+## How Much to Test
+
+### The rule of inputs
+
+Think in terms of **inputs to the unit under test**:
+
+| Input type | Example | Test it? |
+|---|---|---|
+| Props/args that change behavior | `session={null}` vs `session={...}` | Yes |
+| User interactions | click, type, submit | Yes |
+| API response (happy path) | fetch returns data | Yes |
+| API response (failure) | fetch throws | Yes, once per distinct behavior |
+| Many error codes with equivalent handling | 10 BackendApiError codes producing the same result | Test representative equivalence classes |
+| Exact rendered strings | "Ownership verified via DNS TXT" | Only when the wording is a contract |
+| Internal state shape | `useState` value | No — test what the user sees |
+| Timer/debounce behavior | 1500ms delay fires | Maybe, if it's user-facing |
+
+### Coverage targets
+
+Use the coverage tool already configured by the repository. For repositories using Vitest, `@vitest/coverage-v8` measures line, branch, function, and statement coverage; Solidity and other repositories may use different tools.
+
+The following Vitest thresholds are a possible starting point, not an organization-wide mandate. Set thresholds per repository based on its baseline, risk, and ability to enforce them without encouraging low-value tests:
+
+```ts
+coverage: {
+  thresholds: {
+    lines: 80,
+    branches: 70,
+    functions: 80,
+  },
+}
+```
+
+When configured, thresholds are floors, not goals. Going from 80% to 95% often means writing low-value tests for obscure branches. Focus effort on testing critical paths well rather than chasing a number.
+
+**What coverage actually measures:**
+- Line coverage: "Was this line executed during any test?" — does not prove the line works correctly.
+- Branch coverage: "For each conditional, were both true/false paths taken?" — more useful than line coverage.
+- Function coverage: "Was this function ever called?" — lowest bar, useful for finding dead code.
+
+A component can have 100% line coverage and still be broken if the tests only assert that it doesn't crash. Coverage answers "was this code reached?" — not "does this code work?"
+
+---
+
+## Test Structure
+
+### One coherent behavior per test
+
+Each test should verify one coherent behavior or scenario. Multiple assertions are fine when they jointly prove the same outcome. Split a test when it covers independent behaviors, has unrelated failure reasons, or requires substantially different setup.
+
+```ts
+// Too broad: three independently failing behaviors
+it('loads data, shows the list, and handles pagination')
+
+// Good
+it('shows a loading spinner before data arrives')
+it('renders all items after data loads')
+it('loads the next page when the user scrolls to the bottom')
+```
+
+### Use describe blocks for shared context
+
+Group tests by the condition they test, not by the function they call.
+
+```ts
+describe('AccountPage', () => {
+  describe('when unauthenticated', () => { ... })
+  describe('when authenticated with a free plan', () => { ... })
+  describe('when editing the display name', () => { ... })
+})
+```
+
+### Keep setup close to the test
+
+Prefer per-test setup over large `beforeEach` blocks. When `beforeEach` grows past 20 lines of mock configuration, it becomes hard to see what each test actually depends on. Use helper functions instead:
+
+```ts
+function renderWithSession(session: Session) {
+  mockUseBackendSession.mockReturnValue({ session })
+  return render(<AccountPage />)
+}
+```
+
+---
+
+## AI-Generated Tests
+
+AI tools (Cursor, Copilot, etc.) can generate test suites quickly. They also tend to:
+
+1. **Over-test exact strings** — because they see the string in the source and assert it verbatim.
+2. **Duplicate the same pattern 10x** — testing every error code individually instead of parameterizing.
+3. **Test mock wiring** — asserting that mocks were called rather than that UI changed.
+4. **Create massive files** — 2,000+ line test files that nobody will review properly.
+
+**Before merging an AI-generated test PR:**
+
+- Run the repository's documented test command and confirm the relevant suite passes
+- Spot-check a representative sample by temporarily breaking the implementation and confirming the test fails; restore the implementation afterward and verify no accidental diff remains
+- Look for tests that would pass even if the component rendered nothing — these test mock setup, not behavior
+- Treat a test file over 500 lines as a review signal, not an automatic failure; split or trim it when that improves comprehension
+- Remove repetitive fallback tests when they cover the same centralized implementation rather than distinct behavior
+
+---
+
+## CI Integration
+
+Where configured, tests run in a separate `test` job in `ci.yml`. The test job is **not** a required status check for merge (see [governance README](README.md) for rationale). Required-check configuration and review judgment are separate:
+
+- A failure newly caused by a production-code change is blocking evidence of a regression
+- A documented pre-existing failure does not become the current PR's responsibility
+- A test-only PR may intentionally expose an existing implementation bug; document it and track the implementation fix separately
+- Coverage thresholds apply wherever the repository's coverage command runs; enforcement requires that command and its thresholds to be configured in CI
+
+---
+
+## Per-Repo Test Specs
+
+Some repositories have detailed test specifications (e.g., `oma3-ops/test/README.md`). These are authoritative for their repo. This document provides the cross-repo defaults and philosophy. When in conflict, the repo-specific spec wins for that repo.


### PR DESCRIPTION
## Risk Level

**Risk:** low

## Summary

Adds documents that prevent main and staging branches from diverging.

Add guidance documents on reviewing and writing test cases.

## Testing Performed

Not necessary

## CI Status

- [x] All required checks pass
